### PR TITLE
fix transform combinations

### DIFF
--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -14,12 +14,12 @@ class FigureElement(object):
         self.root = xml_element 
 
     def moveto(self, x, y, scale=1):
-        self.root.set("transform", "translate(%s, %s) scale(%s)" %
-                (x,y, scale))
+        self.root.set("transform", "%s translate(%s, %s) scale(%s)" %
+                (self.root.get("transform") or '', x,y, scale))
 
     def rotate(self, angle, x=0, y=0):
-        self.root.set("transform", "rotate(%f %f %f)" %
-                (angle,x, y))
+        self.root.set("transform", "%s rotate(%f %f %f)" %
+                (self.root.get("transform") or '', angle,x, y))
 
 
     def __getitem__(self, i):


### PR DESCRIPTION
now a list of commands like this works, before only the last command was executed

f.moveto(x,y)
f.rotate(alpha1)
f.moveto(x1,y1)
...
