### PR TITLE
fixed typo where column width and row height was not named correctly

### DIFF
--- a/src/svgutils/templates.py
+++ b/src/svgutils/templates.py
@@ -47,7 +47,7 @@ class ColumnLayout(BaseTemplate):
 
         self.nrows = nrows
         self.col_width = col_width
-        self.row_width = row_height
+        self.row_height = row_height
 
         BaseTemplate.__init__(self)
 
@@ -64,7 +64,7 @@ class ColumnLayout(BaseTemplate):
         
         if self.col_width is None:
             self.col_width = transform_list[0]['width']
-        if self.row_width is None:
+        if self.row_height is None:
             self.row_height = transform_list[0]['height']
 
         for i in range(rows):


### PR DESCRIPTION
Hi, 

I found at typo where row_width and row_height were mixed.

/Henrik
