### PR TITLE
Transformations

### DIFF
--- a/src/svgutils/compose.py
+++ b/src/svgutils/compose.py
@@ -64,24 +64,6 @@ class Element(_transform.FigureElement):
         self.moveto(x, y, 1)
         return self
 
-    def skew(self, x, y):
-        """
-
-        Parameters
-        ----------
-        x,y : float, float
-            skew angle in degrees
-
-            If an x/y angle is given as zero degrees, that transformation is omitted.
-        """
-
-        if x is not 0:
-            self.skewX(self, x)
-        if y is not 0:
-            self.skewY(self, y)
-
-        return self
-
     def find_id(self, element_id):
         """Find a single element with the given ID.
 

--- a/src/svgutils/compose.py
+++ b/src/svgutils/compose.py
@@ -64,6 +64,24 @@ class Element(_transform.FigureElement):
         self.moveto(x, y, 1)
         return self
 
+    def skew(self, x, y):
+        """
+
+        Parameters
+        ----------
+        x,y : float, float
+            skew angle in degrees
+
+            If an x/y angle is given as zero degrees, that transformation is omitted.
+        """
+
+        if x is not 0:
+            self.skewX(self, x)
+        if y is not 0:
+            self.skewY(self, y)
+
+        return self
+
     def find_id(self, element_id):
         """Find a single element with the given ID.
 

--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -49,29 +49,27 @@ class FigureElement(object):
         self.root.set("transform", "%s rotate(%f %f %f)" %
                       (self.root.get("transform") or '', angle, x, y))
 
-    def skew_x(self, angle):
-        """Skew element along the x-axis by the given angle.
+    def skew(self, x=0, y=0):
+        """Skew the element by x and y degrees
 
         Parameters
         ----------
-        angle : float
-            x-axis skew angle in degrees
+        x,y : float, float
+            skew angle in degrees (default 0)
+
+            If an x/y angle is given as zero degrees, that transformation is omitted.
         """
-        self.root.set("transform", "%s skewX(%f)" %
-                      (self.root.get("transform") or '', angle))
 
-    def skew_y(self, angle):
-        """Skew element along the y-axis by the given angle.
+        if x is not 0:
+            self.root.set("transform", "%s skewX(%f)" %
+                          (self.root.get("transform") or '', x))
+        if y is not 0:
+            self.root.set("transform", "%s skewY(%f)" %
+                          (self.root.get("transform") or '', y))
 
-        Parameters
-        ----------
-        angle : float
-            y-axis skew angle in degrees
-        """
-        self.root.set("transform", "%s skewY(%f)" %
-                      (self.root.get("transform") or '', angle))
+        return self
 
-    def scale_xy(self, x, y=None):
+    def scale_xy(self, x=0, y=None):
         """Scale element separately across the two axes x and y.
             If y is not provided, it is assumed equal to x (according to the
             W3 specification).

--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -51,6 +51,7 @@ class FigureElement(object):
 
     def skew(self, x=0, y=0):
         """Skew the element by x and y degrees
+        Convenience function which calls skew_x and skew_y
 
         Parameters
         ----------
@@ -59,14 +60,35 @@ class FigureElement(object):
 
             If an x/y angle is given as zero degrees, that transformation is omitted.
         """
-
         if x is not 0:
-            self.root.set("transform", "%s skewX(%f)" %
-                          (self.root.get("transform") or '', x))
+            self.skew_x(x)
         if y is not 0:
-            self.root.set("transform", "%s skewY(%f)" %
-                          (self.root.get("transform") or '', y))
+            self.skew_y(y)
 
+        return self
+
+    def skew_x(self, x):
+        """Skew element along the x-axis by the given angle.
+
+        Parameters
+        ----------
+        x : float
+            x-axis skew angle in degrees
+        """
+        self.root.set("transform", "%s skewX(%f)" %
+                      (self.root.get("transform") or '', x))
+        return self
+
+    def skew_y(self, y):
+        """Skew element along the y-axis by the given angle.
+
+        Parameters
+        ----------
+        y : float
+            y-axis skew angle in degrees
+        """
+        self.root.set("transform", "%s skewY(%f)" %
+                      (self.root.get("transform") or '', y))
         return self
 
     def scale_xy(self, x=0, y=None):

--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -49,7 +49,7 @@ class FigureElement(object):
         self.root.set("transform", "%s rotate(%f %f %f)" %
                       (self.root.get("transform") or '', angle, x, y))
 
-    def skewX(self, angle):
+    def skew_x(self, angle):
         """Skew element along the x-axis by the given angle.
 
         Parameters
@@ -60,7 +60,7 @@ class FigureElement(object):
         self.root.set("transform", "%s skewX(%f)" %
                       (self.root.get("transform") or '', angle))
 
-    def skewY(self, angle):
+    def skew_y(self, angle):
         """Skew element along the y-axis by the given angle.
 
         Parameters
@@ -71,8 +71,7 @@ class FigureElement(object):
         self.root.set("transform", "%s skewY(%f)" %
                       (self.root.get("transform") or '', angle))
 
-
-    def scaleXY(self, x, y=None):
+    def scale_xy(self, x, y=None):
         """Scale element separately across the two axes x and y.
             If y is not provided, it is assumed equal to x (according to the
             W3 specification).
@@ -88,7 +87,7 @@ class FigureElement(object):
         self.root.set("transform", "%s scale(%f %f)" %
                       (self.root.get("transform") or '',
                        x, y if y is not None else ''))
-        
+
     def __getitem__(self, i):
         return FigureElement(self.root.getchildren()[i])
 

--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -71,6 +71,24 @@ class FigureElement(object):
         self.root.set("transform", "%s skewY(%f)" %
                       (self.root.get("transform") or '', angle))
 
+
+    def scaleXY(self, x, y=None):
+        """Scale element separately across the two axes x and y.
+            If y is not provided, it is assumed equal to x (according to the
+            W3 specification).
+
+        Parameters
+        ----------
+        x : float
+            x-axis scaling factor. To scale down x < 1, scale up x > 1.
+        y : (optional) float
+            y-axis scaling factor. To scale down y < 1, scale up y > 1.
+
+        """
+        self.root.set("transform", "%s scale(%f %f)" %
+                      (self.root.get("transform") or '',
+                       x, y if y is not None else ''))
+        
     def __getitem__(self, i):
         return FigureElement(self.root.getchildren()[i])
 

--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -49,6 +49,28 @@ class FigureElement(object):
         self.root.set("transform", "%s rotate(%f %f %f)" %
                       (self.root.get("transform") or '', angle, x, y))
 
+    def skewX(self, angle):
+        """Skew element along the x-axis by the given angle.
+
+        Parameters
+        ----------
+        angle : float
+            x-axis skew angle in degrees
+        """
+        self.root.set("transform", "%s skewX(%f)" %
+                      (self.root.get("transform") or '', angle))
+
+    def skewY(self, angle):
+        """Skew element along the y-axis by the given angle.
+
+        Parameters
+        ----------
+        angle : float
+            y-axis skew angle in degrees
+        """
+        self.root.set("transform", "%s skewY(%f)" %
+                      (self.root.get("transform") or '', angle))
+
     def __getitem__(self, i):
         return FigureElement(self.root.getchildren()[i])
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -24,3 +24,21 @@ def test_group_class():
     group = svg_fig.getroot()
     ok_((group.root.attrib['class'] == 'main'))
 
+def test_skew():
+    svg_fig = transform.fromstring(circle)
+    group = svg_fig.getroot()
+
+    # Test skew in y-axis
+    group.skew(0, 30)
+    ok_('skewY(30' in group.root.get('transform'))
+
+    # Test skew in x-axis
+    group.skew(30, 0)
+    ok_('skewX(30' in group.root.get('transform'))
+
+def test_scale_xy():
+    svg_fig = transform.fromstring(circle)
+    group = svg_fig.getroot()
+
+    group.scale_xy(0, 30)
+    ok_('scale(0' in group.root.get('transform'))


### PR DESCRIPTION
First of all, awesome project. I'm using it to composite figures from matplotlib overlaid on a cartopy map: I've added functionality which allows to compensate for skewed projections and I figured I'd contribute this back.

In this PR, I've expanded the transform functionality of `svgutils.compose.Element` and `svgutils.transform.FigureElement` to include further transformation definitions for:

 * scaling an element separately across axis X and Y, using the `scale(x,[y])` definition; 
 * skewing the element separately across X and Y, using the `skewX(x)` and `skewY(y)` definitions.

The changes include the docstrings for these methods and should be PEP8 compliant.

Cheers.