### PR TITLE
Fixed broken import

### DIFF
--- a/src/svgutils/templates.py
+++ b/src/svgutils/templates.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #coding=utf-8
 
-from transform import SVGFigure, GroupElement
+from svgutils.transform import SVGFigure, GroupElement
 
 class BaseTemplate(SVGFigure):
 


### PR DESCRIPTION
This import as it was, does not work if you install svgutils as a package. You get for example if you execute examples/stack_svg.py:

```
.../svgutils/templates.py", line 4, in <module>
ImportError: No module named 'transform'
```

I have now fixed it.