### PR TITLE
Included build files into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swc
 *.pyc
 docs/build
+build/
+dist/
+src/svgutils.egg-info/


### PR DESCRIPTION
It was annoying to remove all build files by hand before an commit to not accidentially push build files. So I added them to the .gitignore