### PR TITLE
Added "font-style" option to TextElement plus additional opts dict

### DIFF
--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -141,14 +141,15 @@ class TextElement(FigureElement):
     Corresponds to SVG ``<text>`` tag."""
     def __init__(self, x, y, text, size=8, font="Verdana",
                  weight="normal", letterspacing=0, anchor='start',
-                 color='black'):
+                 color='black', style="normal", opts={}):
         txt = etree.Element(SVG+"text", {"x": str(x), "y": str(y),
                                          "font-size": str(size),
                                          "font-family": font,
                                          "font-weight": weight,
                                          "letter-spacing": str(letterspacing),
                                          "text-anchor": str(anchor),
-                                         "fill": str(color)})
+                                         "fill": str(color),
+                                         "font-style": style}.update(opts))
         txt.text = text
         FigureElement.__init__(self, txt)
 

--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -142,14 +142,17 @@ class TextElement(FigureElement):
     def __init__(self, x, y, text, size=8, font="Verdana",
                  weight="normal", letterspacing=0, anchor='start',
                  color='black', style="normal", opts={}):
-        txt = etree.Element(SVG+"text", {"x": str(x), "y": str(y),
-                                         "font-size": str(size),
-                                         "font-family": font,
-                                         "font-weight": weight,
-                                         "letter-spacing": str(letterspacing),
-                                         "text-anchor": str(anchor),
-                                         "fill": str(color),
-                                         "font-style": style}.update(opts))
+        attrs = {
+            "x": str(x), "y": str(y),
+            "font-size": str(size),
+            "font-family": font,
+            "font-weight": weight,
+            "letter-spacing": str(letterspacing),
+            "text-anchor": str(anchor),
+            "fill": str(color),
+            "font-style": style}
+        attrs.update(opts)
+        txt = etree.Element(SVG+"text", attrs)
         txt.text = text
         FigureElement.__init__(self, txt)
 


### PR DESCRIPTION
As well as adding the "font-style" attribute directly, an option dictionary was added to allow the user to specify any other attributes, such as dx, dy, rotate etc.