### PR TITLE
add __repr__ method for Unit class

### DIFF
--- a/src/svgutils/compose.py
+++ b/src/svgutils/compose.py
@@ -370,6 +370,9 @@ class Unit:
     def __str__(self):
         return "{}{}".format(self.value, self.unit)
 
+    def __repr__(self):
+        return "Unit({})".format(str(self))
+
     def __mul__(self, number):
         u = Unit("0cm")
         u.value = self.value * number


### PR DESCRIPTION
In addition to __str__ it can be convenient to define __repr__ method 