### PR TITLE
Enable huge trees

### DIFF
--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -314,7 +314,7 @@ def fromfile(fname):
     """
     fig = SVGFigure()
     with open(fname) as fid:
-        svg_file = etree.parse(fid)
+        svg_file = etree.parse(fid, parser=etree.XMLParser(huge_tree=True))
 
     fig.root = svg_file.getroot()
     return fig
@@ -335,7 +335,7 @@ def fromstring(text):
         content.
     """
     fig = SVGFigure()
-    svg = etree.fromstring(text.encode())
+    svg = etree.fromstring(text.encode(), parser=etree.XMLParser(huge_tree=True))
 
     fig.root = svg
 


### PR DESCRIPTION
This will allow users to manipulate large svg files, for example, with embedded images.
If you have concerns about making it default, tell me so I can add it as an optional argument which defaults to ```False``` :)