### PR TITLE
Make GitHub Dependabot keep existing GitHub Actions up to date (for free)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Copyright (C) 2021 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT License
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Will make GitHub Dependabot create pull requests for review (like the one at https://github.com/git-big-picture/git-big-picture/pull/46). It works great over there. What do you think?