### PR TITLE
Drop macOS from CI to save resources?

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.9]  # no explicit need for 3.7, 3.8
-        runs-on: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: actions/setup-python@v2.1.4


### PR DESCRIPTION
I noticed that the macOS CI is often lagging behind noticeably and we would save resources — time (but also CPU, disk, network traffic, energy) — while we don't have anything platform specific in the code base. @btel what do you think?