### PR TITLE
Allow svg import without width/height attributes

### DIFF
--- a/src/svgutils/compose.py
+++ b/src/svgutils/compose.py
@@ -119,11 +119,11 @@ class SVG(Element):
             super(SVG, self).__init__(svg.getroot().root)
 
             # if height/width is in % units, we can't store the absolute values
-            if svg.width.endswith("%"):
+            if svg.width is None or svg.width.endswith("%"):
                 self._width = None
             else:
                 self._width = Unit(svg.width).to("px")
-            if svg.height.endswith("%"):
+            if svg.height is None or svg.height.endswith("%"):
                 self._height = None
             else:
                 self._height = Unit(svg.height).to("px")


### PR DESCRIPTION
This is possible in an `.svg` file, as indicated by this stackexchange post [1]. I also have created them and they render just fine. Further, your code seems to already support having a `None` value for `self._height` and `self._width` so it seems that not much has to change.

Without this check, the code raises an exception. 

```
...
  File "/home/jonnyjack7/.local/lib/python3.9/site-packages/svgutils/compose.py", line 122, in __init__         
    if svg.width.endswith("%"):
AttributeError: 'NoneType' object has no attribute 'endswith'
```

[1] https://graphicdesign.stackexchange.com/a/71574