### PR TITLE
bugfix : build SVGFigure create a wrong <svg/> 'no viewbox'

### DIFF
--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -258,7 +258,7 @@ class SVGFigure(object):
 
     @width.setter
     def width(self, value):
-        self._width = value.value
+        self._width = value
         self.root.set("width", str(value))
         self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
 
@@ -269,7 +269,7 @@ class SVGFigure(object):
 
     @height.setter
     def height(self, value):
-        self._height = value.value
+        self._height = value
         self.root.set("height", str(value))
         self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
 


### PR DESCRIPTION
The create of
SVGFigure(width="16cm",height="16cm")
raise a catched exception
the viewbox is not create in the <svg/>

"it will nice to have unit test"