### PR TITLE
FigureElement creates a copy of self instead of root xml_element

### DIFF
--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -123,7 +123,7 @@ class FigureElement(object):
 
     def copy(self):
         """Make a copy of the element"""
-        return deepcopy(self.root)
+        return deepcopy(self)
 
     def tostr(self):
         """String representation of the element"""


### PR DESCRIPTION
Fixed the behaviour of FigureElement coy, it now creates a deep copy of self instead of the root xml_element