### PR TITLE
Actions: Restore CI job "lint" for now for a fully green CI

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - uses: actions/setup-python@v4.2.0
       - uses: psf/black@22.8.0
-        env:
-          INPUT_BLACK_ARGS: --target-version py36
+        with:
+          options: --check --diff --target-version py36 --exclude ^/docs/source/conf\.py$

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-python@v2.1.4
-      - uses: psf/black@20.8b1
+      - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-python@v4.2.0
+      - uses: psf/black@22.8.0
         env:
           INPUT_BLACK_ARGS: --target-version py36

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,13 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-python@v2.1.4
+      - uses: psf/black@20.8b1
+        env:
+          INPUT_BLACK_ARGS: --target-version py36


### PR DESCRIPTION
The hope is to get to a fully green CI and to then try delete job `lint` once more when all other pull requests have been merged, later.