### PR TITLE
Update deps in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3
@@ -8,6 +8,6 @@ repos:
         exclude: '^docs/source/conf\.py$'
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort


### PR DESCRIPTION
I was making a commit for another PR but the pre-commit hook had an error, which seems to be a problem with isort version 5.10.1 and poetry, see here: https://stackoverflow.com/questions/75281731/pre-commit-fails-to-install-isort-5-10-1-with-error-runtimeerror-the-poetry-co. This PR fixes that.