### PR TITLE
Raise with nicer error message if unit is invalid

### DIFF
--- a/src/svgutils/common.py
+++ b/src/svgutils/common.py
@@ -18,6 +18,8 @@ class Unit:
             self.unit = "px"
         except ValueError:
             m = re.match("([0-9]+\.?[0-9]*)([a-z]+)", measure)
+            if m is None:
+                raise ValueError("Could not parse unit in {!r}".format(measure))
             value, unit = m.groups()
             self.value = float(value)
             self.unit = unit

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,7 +1,7 @@
 import codecs
 import hashlib
 
-from nose.tools import assert_almost_equal, ok_
+from nose.tools import assert_almost_equal, assert_raises, ok_
 
 import svgutils.compose as sc
 from svgutils.compose import *
@@ -58,6 +58,11 @@ def test_units():
     length = Unit("10.5cm")
     assert length.unit == "cm"
     assert length.value == 10.5
+
+    with assert_raises(ValueError) as cm:
+        Unit("x")
+    ex = cm.exception
+    assert str(ex) == "Could not parse unit in 'x'"
 
 
 def test_unit_div():


### PR DESCRIPTION
When I was using `svgutils` for the first time and tried to use `svgutils.compose.Figure`, I had a typo in one of the units, which caused the following confusing error:
```
AttributeError: 'NoneType' object has no attribute 'groups'
```
This took me a while to figure out. With this PR, the error is a much nicer
```
ValueError: Could not parse unit in 'typo'
```