### PR TITLE
Fix SyntaxError from non-raw regular expression

### DIFF
--- a/src/svgutils/common.py
+++ b/src/svgutils/common.py
@@ -17,7 +17,7 @@ class Unit:
             self.value = float(measure)
             self.unit = "px"
         except ValueError:
-            m = re.match("([0-9]+\.?[0-9]*)([a-z]+)", measure)
+            m = re.match(r"([0-9]+\.?[0-9]*)([a-z]+)", measure)
             value, unit = m.groups()
             self.value = float(value)
             self.unit = unit
@@ -41,10 +41,10 @@ class Unit:
         return u
 
     def __str__(self):
-        return "{}{}".format(self.value, self.unit)
+        return f"{self.value}{self.unit}"
 
     def __repr__(self):
-        return "Unit({})".format(str(self))
+        return f"Unit({self})"
 
     def __mul__(self, number):
         u = Unit("0cm")

--- a/src/svgutils/compose.py
+++ b/src/svgutils/compose.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding=utf-8
 """SVG definitions designed for easy SVG composing
 
 Features:
@@ -44,7 +43,7 @@ class Element(_transform.FigureElement):
             pivot coordinates in user coordinate system (defaults to top-left
             corner of the figure)
         """
-        super(Element, self).rotate(angle, x, y)
+        super().rotate(angle, x, y)
         return self
 
     def move(self, x, y):
@@ -116,7 +115,7 @@ class SVG(Element):
             if fix_mpl:
                 w, h = svg.get_size()
                 svg.set_size((w.replace("pt", ""), h.replace("pt", "")))
-            super(SVG, self).__init__(svg.getroot().root)
+            super().__init__(svg.getroot().root)
 
             # if height/width is in % units, we can't store the absolute values
             if svg.width.endswith("%"):

--- a/src/svgutils/templates.py
+++ b/src/svgutils/templates.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding=utf-8
 
 from svgutils.transform import GroupElement, SVGFigure
 

--- a/src/svgutils/transform.py
+++ b/src/svgutils/transform.py
@@ -17,7 +17,7 @@ XLINK = "{%s}" % XLINK_NAMESPACE
 NSMAP = {None: SVG_NAMESPACE, "xlink": XLINK_NAMESPACE}
 
 
-class FigureElement(object):
+class FigureElement:
     """Base class representing single figure element"""
 
     def __init__(self, xml_element, defs=None):
@@ -228,7 +228,7 @@ class GroupElement(FigureElement):
         self.root = new_group
 
 
-class SVGFigure(object):
+class SVGFigure:
     """SVG Figure.
 
     It setups standalone SVG tree. It corresponds to SVG ``<svg>`` tag.
@@ -258,7 +258,7 @@ class SVGFigure(object):
             value = Unit(value)
         self._width = value.value
         self.root.set("width", str(value))
-        self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
+        self.root.set("viewBox", f"0 0 {self._width} {self._height}")
 
     @property
     def height(self):
@@ -271,7 +271,7 @@ class SVGFigure(object):
             value = Unit(value)
         self._height = value.value
         self.root.set("height", str(value))
-        self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
+        self.root.set("viewBox", f"0 0 {self._width} {self._height}")
 
     def append(self, element):
         """Append new element to the SVG figure"""


### PR DESCRIPTION
It seems that invalid escape sequences will at some undetermined point in the future stop emitting SyntaxWarnings and start emitting SyntaxErrors (see the second bullet item in https://docs.python.org/3/whatsnew/3.12.html#other-language-changes).

On the whole, svgutils seems not to need changes to be usable on new versions of Python, but this warning is no longer safe to ignore.

Only the first change is really necessary, but I used `pyupgrade --py36-plus` to just make safe upgrades. I only included conversions away from `%`-formatted strings if they actually made the line shorter.